### PR TITLE
Prefer to link against namespaced library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,5 +23,4 @@ add_executable(testExe
 
 message(STATUS "Catch include dir: ${catch2_SOURCE_DIR}/include")
 
-target_link_libraries(testExe Catch) #case sensitive!
-
+target_link_libraries(testExe Catch2::Catch) # Prefer namespaced library


### PR DESCRIPTION
This ensures CMake will complain if the named target is not a CMake
target (it won't do that for unnamespaced names, it will assume the
library exists somewhere on the search path in such cases and fail
at link time).